### PR TITLE
Fixed an issue where "clearing" cache doesn't actually clear cache as expected

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,12 +36,14 @@ FileCache.prototype.cache = function() {
     return callback();
   }
 
-  // flush cache to disk
-  function flush(callback) {
-    fs.writeFile(_this._filename, JSON.stringify(_this._cache), callback);
-  }
+  var flush = this.flush.bind(_this);
 
   return through.obj(transform, flush);
+};
+
+FileCache.prototype.flush = function(callback) {
+  // flush cache to disk
+  fs.writeFile(this._filename, JSON.stringify(this._cache), callback);
 };
 
 /**
@@ -50,8 +52,9 @@ FileCache.prototype.cache = function() {
  * @api public
  */
 
-FileCache.prototype.clear = function() {
+FileCache.prototype.clear = function(emptyCache) {
   this._cache = {};
+  if (emptyCache) this.flush();
 };
 
 /**


### PR DESCRIPTION
My use case is running JSCS on my entire project, caching all of the files the first round through, and then every sequential run via watch, only hitting the files that have changes from the previous cache.

When creating a gulp task to call the `FIleCache.clear()` function, it didn't actually clear the cache.

It does a soft clear and will, but never a hard clear to actually dump the cache file from disk.  This is useful, but not for everybody.
